### PR TITLE
Update legacy `.keys()` list subscription

### DIFF
--- a/lib/graphics_ctrl.py
+++ b/lib/graphics_ctrl.py
@@ -84,7 +84,7 @@ class Table(object):
         pygame.display.flip()
 
     def display_card(self, card_msg):
-        player = card_msg.keys()[0]
+        player = list(card_msg.keys())[0]
         card = ''.join(i for i in card_msg[player])
         self.player_data[str(player)].append(card)
         card = pygame.image.load(PATH + card)


### PR DESCRIPTION
`Python3` doesn't `.keys()` returns a `dict_keys` object in place of `list`.  This converts `dict_keys` to a list.